### PR TITLE
Support for reading standard proxy env variables

### DIFF
--- a/download-chromedriver.js
+++ b/download-chromedriver.js
@@ -13,8 +13,10 @@ var baseUrl = process.env.NPM_CONFIG_ELECTRON_MIRROR ||
 
 var proxy = process.env.NPM_CONFIG_HTTPS_PROXY ||
   process.env.npm_config_https_proxy ||
+  process.env.HTTPS_PROXY ||
   process.env.NPM_CONFIG_PROXY ||
-  process.env.npm_config_proxy
+  process.env.npm_config_proxy ||
+  process.env.HTTP_PROXY
 
 var config = {
   baseUrl: baseUrl,


### PR DESCRIPTION
When using `request` it should already be taking advantage of these per the [documentation](https://docs.npmjs.com/misc/config), but if I use the npm config variables for proxy, then it won't use the no proxy information per [this open issue](https://github.com/npm/npm/issues/7168).  Will adding these in allow me to use `HTTP_PROXY` and `HTTPS_PROXY` so that my `NO_PROXY` configurations are respected?

> A proxy to use for outgoing http requests. If the HTTP_PROXY or http_proxy environment variables are set, proxy settings will be honored by the underlying request library.